### PR TITLE
Feedback

### DIFF
--- a/commands/fbmute.js
+++ b/commands/fbmute.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const profileModel = require('../models/profileSchema');
+
+module.exports = {
+    name: "fbmute",
+    cooldown: 5,
+    aliases: ["fbm", "fm"],
+    description: "Mute or unmute someone from sending feedback.",
+    usage: ".fbmute `[tag]`",
+    options: [
+        {
+            name: "tag",
+            description: "Tag of the person you want to (un)mute (do not mention them)",
+            required: true,
+            type: 3
+        }
+    ],
+    async execute(client, interaction, args, Discord, profileData) {
+        const user = client.users.cache.find(u => u.tag === args[0])
+        const admin = (await client.guilds.cache.get('876363041703350272').members.fetch()).get(interaction.member.id);
+        if(typeof admin !== "undefined" && typeof admin.roles.cache.get("911865219091943494") !== "undefined") {
+            if(typeof user !== "undefined") {
+                extraData = await profileModel.findOne({ userID: user.id });
+                if(!extraData) {
+                    let profile = await profileModel.create({
+                        userID: interaction.member.id,
+                        serverID: interaction.guild.id,
+                        coins: 1000,
+                        bank: 0,
+                        resources: {},
+                        items: {},
+                        equipped: "",
+                        autoStats: {efficiency:0, cost:0, exp: 0, special: 0},
+                        fbmuted: true
+                    });
+                   profile.save();
+                   extraData = await profileModel.findOne({ userID: interaction.member.id });
+                   interaction.reply(`User ${args[0]} has been muted!`)
+                } else if (typeof extraData.fbmuted === "undefined" || !extraData.fbmuted) {
+                    const response = await profileModel.findOneAndUpdate({
+                        userID: user.id
+                    }, {
+                        $set: {fbmuted:true},
+                    });
+                    interaction.reply(`User ${args[0]} has been muted!`)
+                } else if (extraData.fbmuted) {
+                    const response = await profileModel.findOneAndUpdate({
+                        userID: user.id
+                    }, {
+                        $set: {fbmuted:false},
+                    });
+                    interaction.reply(`User ${args[0]} has been unmuted!`)
+                }
+            } else {
+                interaction.reply("That user could not be found, make sure it is the right tag and that they share a server with the bot.")
+            }
+        } else {
+            interaction.reply("You do not have permission for this command! Only Admins on the official Starship server can use this.")
+        }
+    }
+}

--- a/commands/feedback.js
+++ b/commands/feedback.js
@@ -1,0 +1,40 @@
+const profileModel = require('../models/profileSchema');
+
+module.exports = {
+    name: "feedback",
+    cooldown: 300,
+    aliases: ["fb", "f"],
+    description: "Send us feedback/bug reports.",
+    usage: ".feedback `[report]",
+    options: [
+        {
+            name: "type",
+            description: "Type of report. Can be bug, advice, or feedback",
+            required: true,
+            type: 3
+        },{
+            name: "report",
+            description: "Advice/report you want to send the dev team",
+            required: true,
+            type: 3
+        }
+    ],
+    async execute(client, interaction, args, Discord, profileData) {
+        const type = args[0]
+        const report = args[1]
+        var reportEmbed = new Discord.MessageEmbed()
+            .setColor([47,158,66])
+            .setTitle(`Report from ${interaction.member}:`)
+            .setDescription(report)
+        switch(type.toLowerCase()) {
+            case "bug": reportEmbed = reportEmbed.setAuthor({name: 'Bug Report', iconURL: 'https://emojipedia-us.s3.amazonaws.com/source/skype/289/exclamation-mark_2757.png'}); break;
+            case "advice" : reportEmbed = reportEmbed.setAuthor({name: 'Advice', iconURL: 'https://www.pngkit.com/png/full/24-243415_orange-question-mark-question-mark-icon-orange.png'}); break;
+            case "feedback" : reportEmbed = reportEmbed.setAuthor({name: 'Feedback', iconURL: 'https://www.venzagroup.com/wp-content/uploads/transparent-green-checkmark-md.png'}); break;
+        }
+        let guild = client.guilds.cache.get('876363041703350272');
+        let channel = await guild.channels.fetch('933514222090989608');
+        channel.send({embeds: [reportEmbed]})
+
+        interaction.reply("Thank you for your feedback! It has been sent off to our developers. We appreciate all the help we can get!")
+    }
+}

--- a/commands/feedback.js
+++ b/commands/feedback.js
@@ -4,7 +4,7 @@ module.exports = {
     name: "feedback",
     cooldown: 300,
     aliases: ["fb", "f"],
-    description: "Send us feedback/bug reports.",
+    description: "Send us feedback/bug reports. Keep in mind that your tag will be associated with this report.",
     usage: ".feedback `[report]",
     options: [
         {
@@ -23,18 +23,26 @@ module.exports = {
         const type = args[0]
         const report = args[1]
         var reportEmbed = new Discord.MessageEmbed()
-            .setColor([47,158,66])
-            .setTitle(`Report from ${interaction.member}:`)
+            .setTitle(`Report from ${interaction.member.user.tag}:`)
             .setDescription(report)
         switch(type.toLowerCase()) {
-            case "bug": reportEmbed = reportEmbed.setAuthor({name: 'Bug Report', iconURL: 'https://emojipedia-us.s3.amazonaws.com/source/skype/289/exclamation-mark_2757.png'}); break;
-            case "advice" : reportEmbed = reportEmbed.setAuthor({name: 'Advice', iconURL: 'https://www.pngkit.com/png/full/24-243415_orange-question-mark-question-mark-icon-orange.png'}); break;
-            case "feedback" : reportEmbed = reportEmbed.setAuthor({name: 'Feedback', iconURL: 'https://www.venzagroup.com/wp-content/uploads/transparent-green-checkmark-md.png'}); break;
+            case "bug": reportEmbed = reportEmbed.setAuthor({name: 'Bug Report', iconURL: 'https://emojipedia-us.s3.amazonaws.com/source/skype/289/exclamation-mark_2757.png'})
+            .setColor([186,37,30]); break;
+            case "advice" : reportEmbed = reportEmbed.setAuthor({name: 'Advice', iconURL: 'https://www.pngkit.com/png/full/24-243415_orange-question-mark-question-mark-icon-orange.png'})
+            .setColor([186,92,20]); break;
+            case "feedback" : reportEmbed = reportEmbed.setAuthor({name: 'Feedback', iconURL: 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Checkmark_green.svg/1200px-Checkmark_green.svg.png'})
+            .setColor([47,158,66]); break;
+            default: interaction.reply("Please enter 'bug', 'advice', or 'feedback' for the 'type' variable"); return;
         }
         let guild = client.guilds.cache.get('876363041703350272');
         let channel = await guild.channels.fetch('933514222090989608');
         channel.send({embeds: [reportEmbed]})
 
-        interaction.reply("Thank you for your feedback! It has been sent off to our developers. We appreciate all the help we can get!")
+        var replyEmbed = new Discord.MessageEmbed()
+            .setTitle(`Thank you for your help!`)
+            .setDescription("This message has been sent off to our testers and developers who will try and get to it as quickly as possible. They may contact you for more info if necessary.")
+            .setColor([47,158,66])
+
+        interaction.reply({embeds: [replyEmbed]})
     }
 }

--- a/commands/feedback.js
+++ b/commands/feedback.js
@@ -5,7 +5,7 @@ module.exports = {
     cooldown: 300,
     aliases: ["fb", "f"],
     description: "Send us feedback/bug reports. Keep in mind that your tag will be associated with this report.",
-    usage: ".feedback `[report]",
+    usage: ".feedback `[report]`",
     options: [
         {
             name: "type",
@@ -20,29 +20,33 @@ module.exports = {
         }
     ],
     async execute(client, interaction, args, Discord, profileData) {
-        const type = args[0]
-        const report = args[1]
-        var reportEmbed = new Discord.MessageEmbed()
-            .setTitle(`Report from ${interaction.member.user.tag}:`)
-            .setDescription(report)
-        switch(type.toLowerCase()) {
-            case "bug": reportEmbed = reportEmbed.setAuthor({name: 'Bug Report', iconURL: 'https://emojipedia-us.s3.amazonaws.com/source/skype/289/exclamation-mark_2757.png'})
-            .setColor([186,37,30]); break;
-            case "advice" : reportEmbed = reportEmbed.setAuthor({name: 'Advice', iconURL: 'https://www.pngkit.com/png/full/24-243415_orange-question-mark-question-mark-icon-orange.png'})
-            .setColor([186,92,20]); break;
-            case "feedback" : reportEmbed = reportEmbed.setAuthor({name: 'Feedback', iconURL: 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Checkmark_green.svg/1200px-Checkmark_green.svg.png'})
-            .setColor([47,158,66]); break;
-            default: interaction.reply("Please enter 'bug', 'advice', or 'feedback' for the 'type' variable"); return;
+        if(typeof profileData.fbmuted === "undefined" || profileData.fbmuted == false) {
+            const type = args[0]
+            const report = args[1]
+            var reportEmbed = new Discord.MessageEmbed()
+                .setTitle(`Report from ${interaction.member.user.tag}:`)
+                .setDescription(report)
+            switch(type.toLowerCase()) {
+                case "bug": reportEmbed = reportEmbed.setAuthor({name: 'Bug Report', iconURL: 'https://emojipedia-us.s3.amazonaws.com/source/skype/289/exclamation-mark_2757.png'})
+                .setColor([186,37,30]); break;
+                case "advice" : reportEmbed = reportEmbed.setAuthor({name: 'Advice', iconURL: 'https://www.pngkit.com/png/full/24-243415_orange-question-mark-question-mark-icon-orange.png'})
+                .setColor([186,92,20]); break;
+                case "feedback" : reportEmbed = reportEmbed.setAuthor({name: 'Feedback', iconURL: 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Checkmark_green.svg/1200px-Checkmark_green.svg.png'})
+                .setColor([47,158,66]); break;
+                default: interaction.reply("Please enter 'bug', 'advice', or 'feedback' for the 'type' variable"); return;
+            }
+            let guild = client.guilds.cache.get('876363041703350272');
+            let channel = await guild.channels.fetch('933514222090989608');
+            channel.send({embeds: [reportEmbed]})
+
+            var replyEmbed = new Discord.MessageEmbed()
+                .setTitle(`Thank you for your help!`)
+                .setDescription("This message has been sent off to our testers and developers who will try and get to it as quickly as possible. They may contact you for more info if necessary.")
+                .setColor([47,158,66])
+
+            interaction.reply({embeds: [replyEmbed]})
+        } else {
+            interaction.reply("You have been banned from the feedback command! If you believe this was done in error please contact administrators on the offical Startship server.")
         }
-        let guild = client.guilds.cache.get('876363041703350272');
-        let channel = await guild.channels.fetch('933514222090989608');
-        channel.send({embeds: [reportEmbed]})
-
-        var replyEmbed = new Discord.MessageEmbed()
-            .setTitle(`Thank you for your help!`)
-            .setDescription("This message has been sent off to our testers and developers who will try and get to it as quickly as possible. They may contact you for more info if necessary.")
-            .setColor([47,158,66])
-
-        interaction.reply({embeds: [replyEmbed]})
     }
 }

--- a/events/guild/interactionCreate.js
+++ b/events/guild/interactionCreate.js
@@ -60,7 +60,7 @@ module.exports = async(Discord, client, interaction) => {
             if(current_time < expiration_time) {
                 const time_left = (expiration_time - current_time) / 1000;
 
-                return interaction.reply(`please wait **${time_left.toFixed(1)}** seconds before using ${interaction.commandName} again.`).then(msg => { setTimeout(() => msg.delete(), 6000)});
+                return interaction.reply({content: `Please wait **${time_left.toFixed(1)}** seconds before using ${interaction.commandName} again.`, fetchReply: true}).then(msg => { setTimeout(() => msg.delete(), 6000)});
             }
         }
 

--- a/events/guild/interactionCreate.js
+++ b/events/guild/interactionCreate.js
@@ -52,7 +52,7 @@ module.exports = async(Discord, client, interaction) => {
 
         const current_time = Date.now();
         const time_stamps = cooldowns.get(interaction.commandName);
-        const cooldown_amount = (interaction.commandName) * 1000;
+        const cooldown_amount = (command.cooldown) * 1000;
 
         if(time_stamps.has(interaction.member.id)) {
             const expiration_time = time_stamps.get(interaction.member.id) + cooldown_amount;

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 const Discord = require('discord.js');
-const client = new Discord.Client({partials : ['MESSAGE', 'CHANNEL', 'REACTION'], intents: ["GUILDS", "GUILD_MESSAGES", "GUILD_MESSAGE_REACTIONS"]});
+const client = new Discord.Client({partials : ['MESSAGE', 'CHANNEL', 'REACTION'], intents: ["GUILDS", "GUILD_MESSAGES", "GUILD_MESSAGE_REACTIONS", "GUILD_MEMBERS"]});
 
 require('dotenv').config();
 

--- a/models/profileSchema.js
+++ b/models/profileSchema.js
@@ -10,7 +10,8 @@ const profileSchema = new mongoose.Schema({
     equipped: {type: String},
     timeAutoStarted: {type: Number},
     autoToComplete: {type: Number},
-    autoStats: {type: Map, of: Number}
+    autoStats: {type: Map, of: Number},
+    fbmuted: {type: Boolean}
 });
 
 const model = mongoose.model("ProfileModels", profileSchema);


### PR DESCRIPTION
- Added /feedback [type] [message]. This command allows you to send feedback directly to the #feedback channel in Starship.
- Added /fbmute [user]. This command prevents a certain user from sending feedback, this likely will not work if the user does not share a server with Starship, preventing preemptive bans.
- Fixed issues with command cooldowns causing bot crashes.